### PR TITLE
determine type of pipenv install based on CI var

### DIFF
--- a/script/setup
+++ b/script/setup
@@ -8,7 +8,6 @@ cd "$(dirname "${0}")/.."
 
 # Install pipenv
 if [ -n "$CI" ]; then
-  echo 'yes'
   pip install pipenv
 else
   pip install -q pipenv --user

--- a/script/setup
+++ b/script/setup
@@ -7,7 +7,8 @@ set -e
 cd "$(dirname "${0}")/.."
 
 # Install pipenv
-if [ -n "${CI+set}" ]; then
+if [ -n "$CI" ]; then
+  echo 'yes'
   pip install pipenv
 else
   pip install -q pipenv --user

--- a/script/setup
+++ b/script/setup
@@ -7,7 +7,12 @@ set -e
 cd "$(dirname "${0}")/.."
 
 # Install pipenv
-pip install -q pipenv --user
+if [ -n "${CI+set}" ]; then
+  echo 'ci yo'
+  pip install pipenv
+else
+  pip install -q pipenv --user
+fi
 
 # Install application dependencies
 script/bootstrap

--- a/script/setup
+++ b/script/setup
@@ -8,7 +8,6 @@ cd "$(dirname "${0}")/.."
 
 # Install pipenv
 if [ -n "${CI+set}" ]; then
-  echo 'ci yo'
   pip install pipenv
 else
   pip install -q pipenv --user


### PR DESCRIPTION
`atat-stack` needs to run each of the `script/setup` scripts, and the `--user` flag for pip install doesn't work. This makes it configurable with an env var.