### PR TITLE
WIP: Database config updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
   - "3.6"
+addons:
+  postgresql: "9.6"
 git:
   submodules: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language: python
 python:
   - "3.6"
+services:
+  - postgresql
 addons:
   postgresql: "9.6"
 git:
   submodules: false
+env:
+  - FLASK_ENV=ci
 
 before_install:
   # Use sed to replace the SSH URL with the public HTTP URL
@@ -17,7 +21,3 @@ before_script:
   - script/cibuild
 script:
   - python -m pytest
-services:
-  - postgresql
-env:
-  - FLASK_ENV=ci

--- a/authz/make_app.py
+++ b/authz/make_app.py
@@ -29,8 +29,15 @@ def make_config():
         "../config/",
         "{}.ini".format(os.getenv("FLASK_ENV", "dev").lower()),
     )
+    OVERRIDE_CONFIG_FILENAME = os.getenv("OVERRIDE_CONFIG_FULLPATH")
+
     config = ConfigParser()
 
-    # ENV_CONFIG will override values in BASE_CONFIG.
-    config.read([BASE_CONFIG_FILENAME, ENV_CONFIG_FILENAME])
+    config_files = [BASE_CONFIG_FILENAME, ENV_CONFIG_FILENAME]
+    if OVERRIDE_CONFIG_FILENAME:
+        config_files.append(OVERRIDE_CONFIG_FILENAME)
+
+    # ENV_CONFIG will override values in BASE_CONFIG
+    # OVERRIDE_CONFIG will override values in ENV_CONFIG or BASE_CONFIG
+    config.read(config_files)
     return map_config(config)

--- a/authz/make_app.py
+++ b/authz/make_app.py
@@ -40,4 +40,18 @@ def make_config():
     # ENV_CONFIG will override values in BASE_CONFIG
     # OVERRIDE_CONFIG will override values in ENV_CONFIG or BASE_CONFIG
     config.read(config_files)
+
+    # Assemble DATABASE_URI value
+    database_url = ('postgres://'
+                   + config.get('default', 'DATABASE_USERNAME')
+                   + ':'
+                   + config.get('default', 'DATABASE_PASSWORD')
+                   + '@'
+                   + config.get('default', 'DATABASE_HOST')
+                   + ':'
+                   + config.get('default', 'DATABASE_PORT')
+                   + '/'
+                   + config.get('default', 'DATABASE_NAME'))
+    config.set('default', 'DATABASE_URI', database_uri)
+
     return map_config(config)

--- a/authz/make_app.py
+++ b/authz/make_app.py
@@ -42,7 +42,7 @@ def make_config():
     config.read(config_files)
 
     # Assemble DATABASE_URI value
-    database_url = ('postgres://'
+    database_uri = ('postgres://'
                    + config.get('default', 'DATABASE_USERNAME')
                    + ':'
                    + config.get('default', 'DATABASE_PASSWORD')

--- a/config/base.ini
+++ b/config/base.ini
@@ -1,5 +1,6 @@
 [default]
 ENVIRONMENT = dev
 DEBUG = false
-DATABASE_URI = postgres://postgres:postgres@localhost/authz
+DATABASE_NAME = authz
+DATABASE_URI = postgres://postgres:postgres@localhost/%(DATABASE_NAME)s
 PORT = 8002

--- a/config/base.ini
+++ b/config/base.ini
@@ -1,6 +1,9 @@
 [default]
 ENVIRONMENT = dev
 DEBUG = false
+DATABASE_HOST = localhost
+DATABASE_PORT = 5432
+DATABASE_USERNAME = postgres
+DATABASE_PASSWORD = postgres
 DATABASE_NAME = authz
-DATABASE_URI = postgres://postgres:postgres@localhost/%(DATABASE_NAME)s
 PORT = 8002

--- a/config/ci.ini
+++ b/config/ci.ini
@@ -1,3 +1,1 @@
 [default]
-DATABASE_NAME = authz
-DATABASE_URI = postgres://postgres:postgres@localhost/%(DATABASE_NAME)s

--- a/config/ci.ini
+++ b/config/ci.ini
@@ -1,2 +1,3 @@
 [default]
-DATABASE_URI = postgres://postgres:postgres@localhost/authz
+DATABASE_NAME = authz
+DATABASE_URI = postgres://postgres:postgres@localhost/%(DATABASE_NAME)s


### PR DESCRIPTION
This PR makes changes to the way that the database uri is derived, and also opens the door for additional overrides when necessary.

- Add a check for an optional 3rd tier configuration file, the path of which comes from an environment variable. This would be used to supply values that are instance specific or generated dynamically without having to replicate the entire general env config file
- Split database config into separate config parameters, enabling the ability to only override the relevant piece